### PR TITLE
chore: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    versioning-strategy: "increase"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary

- add weekly Dependabot updates for the root uv project
- preserve declared dependency bounds with `versioning-strategy: increase`
- add weekly Dependabot updates for GitHub Actions

## Validation

- parsed `.github/dependabot.yml` successfully with Ruby YAML
- `git diff --check`

Requested by John Kennedy.